### PR TITLE
links for frameworks added to README and HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@
 ## APIs used
 * [IMDb](https://imdb-api.com/api)
 * [Watchmode](https://api.watchmode.com/)
+
+## CSS Frameworks
+* [Foundation](https://get.foundation/index.html)
 * [Google Fonts](https://developers.google.com/fonts/docs/developer_api#APIKey)
+* [Font Awesome](https://fontawesome.com/)
 
 ## Usage
 *tbd*

--- a/index.html
+++ b/index.html
@@ -5,6 +5,17 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="assets/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
+      integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    
     <title>ClickForFlicks</title>
 </head>
 <body>


### PR DESCRIPTION
wanted to start implementing the frameworks to our coding by adding the stylesheet to the HTML and I left credits + links in the README